### PR TITLE
Update to Jesque 2 API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>net.greghaines</groupId>
             <artifactId>jesque</artifactId>
-            <version>1.3.1</version>
+            <version>2.0.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/net/lariverosc/jesquespring/SpringJobFactory.java
+++ b/src/main/java/net/lariverosc/jesquespring/SpringJobFactory.java
@@ -1,0 +1,44 @@
+package net.lariverosc.jesquespring;
+
+import net.greghaines.jesque.Job;
+import net.greghaines.jesque.worker.JobFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+public class SpringJobFactory implements JobFactory, ApplicationContextAware {
+
+    private final Logger logger = LoggerFactory.getLogger(SpringJobFactory.class);
+
+    private ApplicationContext applicationContext;
+
+    @Override
+    public Object materializeJob(Job job) throws Exception {
+        Runnable runnableJob = null;
+        if (applicationContext.containsBeanDefinition(job.getClassName())) {//Lookup by bean Id
+            runnableJob = (Runnable) applicationContext.getBean(job.getClassName(), job.getArgs());
+        } else {
+            try {
+                Class clazz = Class.forName(job.getClassName());//Lookup by Class type
+                String[] beanNames = applicationContext.getBeanNamesForType(clazz, true, false);
+                if (applicationContext.containsBeanDefinition(job.getClassName())) {
+                    runnableJob = (Runnable) applicationContext.getBean(beanNames[0], job.getArgs());
+                } else {
+                    if (beanNames != null && beanNames.length == 1) {
+                        runnableJob = (Runnable) applicationContext.getBean(beanNames[0], job.getArgs());
+                    }
+                }
+            } catch (ClassNotFoundException cnfe) {
+                logger.error("Not bean Id or class definition found {}", job.getClassName());
+                throw new Exception("Not bean Id or class definition found " + job.getClassName());
+            }
+        }
+        return runnableJob;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+}

--- a/src/main/java/net/lariverosc/jesquespring/SpringWorker.java
+++ b/src/main/java/net/lariverosc/jesquespring/SpringWorker.java
@@ -16,16 +16,10 @@
 package net.lariverosc.jesquespring;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.atomic.AtomicBoolean;
 import net.greghaines.jesque.Config;
-import net.greghaines.jesque.Job;
-import static net.greghaines.jesque.worker.WorkerEvent.JOB_PROCESS;
-import static net.greghaines.jesque.utils.ResqueConstants.WORKER;
 import net.greghaines.jesque.worker.WorkerImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
@@ -39,70 +33,19 @@ public class SpringWorker extends WorkerImpl implements ApplicationContextAware 
 
     private ApplicationContext applicationContext;
 
-    private final AtomicBoolean processingJob = new AtomicBoolean(false);
-
-    private final String name;
-
-    @Override
-    public boolean isProcessingJob() {
-        return this.processingJob.get();
-    }
-
     /**
      *
      * @param config used to create a connection to Redis
      * @param queues the list of queues to poll
      */
     public SpringWorker(final Config config, final Collection<String> queues) {
-        super(config, queues, Collections.EMPTY_MAP);
-        this.name = createName();
+        super(config, queues, new SpringJobFactory());
     }
 
     @Override
-    protected void process(final Job job, final String curQueue) {
-        logger.info("Process new Job from queue {}", curQueue);
-        try {
-            Runnable runnableJob = null;
-            if (applicationContext.containsBeanDefinition(job.getClassName())) {//Lookup by bean Id
-                runnableJob = (Runnable) applicationContext.getBean(job.getClassName(), job.getArgs());
-            } else {
-                try {
-                    Class clazz = Class.forName(job.getClassName());//Lookup by Class type
-                    String[] beanNames = applicationContext.getBeanNamesForType(clazz, true, false);
-                    if (applicationContext.containsBeanDefinition(job.getClassName())) {
-                        runnableJob = (Runnable) applicationContext.getBean(beanNames[0], job.getArgs());
-                    } else {
-                        if (beanNames != null && beanNames.length == 1) {
-                            runnableJob = (Runnable) applicationContext.getBean(beanNames[0], job.getArgs());
-                        }
-                    }
-                } catch (ClassNotFoundException cnfe) {
-                    logger.error("Not bean Id or class definition found {}", job.getClassName());
-                    throw new Exception("Not bean Id or class definition found " + job.getClassName());
-                }
-            }
-            if (runnableJob != null) {
-                this.processingJob.set(true);
-                this.listenerDelegate.fireEvent(JOB_PROCESS, this, curQueue, job, null, null, null);
-                this.jedis.set(key(WORKER, this.name), statusMsg(curQueue, job));
-                if (isThreadNameChangingEnabled()) {
-                    renameThread("Processing " + curQueue + " since " + System.currentTimeMillis());
-                }
-                final Object result = execute(job, curQueue, runnableJob);
-                success(job, runnableJob, result, curQueue);
-            }
-        } catch (Exception e) {
-            logger.error("Error while processing the job: " + job.getClassName(), e);
-            failure(e, job, curQueue);
-        } finally {
-            this.jedis.del(key(WORKER, this.name));
-            this.processingJob.set(false);
-        }
-    }
-
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
+        ((SpringJobFactory)getJobFactory()).setApplicationContext(applicationContext);
     }
 
     /**


### PR DESCRIPTION
Jesque 2 uses a `JobFactory` class which I've implemented, moving the relevant code from `SpringWorker`. That means a bunch of other things in `SpringWorker` that were duplicating private stuff in the super class can be removed.

The only slightly messy thing is the necessity of passing `applicationContext` to `SpringJobFactory` after it's created. I'd rather do that by making it a constructor argument but that's not possible because the `SpringJobFactory` instance has to be created in the constructor of `SpringWorker` and at that point `applicationContext` hasn't been set yet.

I'm not sure if there's a way to pass the application context to a constructor argument from XML configuration. It didn't seem obvious. It can be done when using annotation-driven configuration by just marking the constructor with `@Autowire`. Not sure if you want to go there, though. If so it would clean up the implementation a little as `applicationContext` could be declared final and passed in to the constructor in both `SpringWorker` and `SpringJobFactory`.