### PR TITLE
Fix the bug about jackson change type and use @Resource @Autowired  inject spring bean to user define Job 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
-/target/
+.classpath
+.project
+.settings/
+target/
+*.class
+stdout


### PR DESCRIPTION
1.When the Job's args has java.lang.Long or java.lang.Float,as the jackson framework do the deserialization operation, it will change the
type java.lang.Long to java.lang.Integer ,and change the java.lang.Float
to java.lang.Double.
2.When I want insert a bean use @Resource or @Autowired,the SpringWork
will throw a Exception.